### PR TITLE
No libgcc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,17 +11,16 @@ source:
         - EHapi.c.patch
 
 build:
-    number: 1
+    number: 2
     skip: True  # [win]
 
 requirements:
     build:
-        - hdf5
+        - hdf5 1.8.15.1
         - zlib
     run:
-        - hdf5
+        - hdf5 1.8.15.1
         - zlib
-        - libgcc
 
 test:
     commands:


### PR DESCRIPTION
This package does not link to `libgomp` so we don't need `libgcc` as a `run` requirement.

Pinning `hdf5` as our `netcdf` will take a while to be out there.