### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,15 +13,15 @@ source:
     - EHapi.c.patch
 
 build:
-  number: 6
+  number: 7
   skip: True  # [win]
 
 requirements:
   build:
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - zlib 1.2.*
   run:
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - zlib 1.2.*
 
 test:


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71