### PR TITLE
[ci skip] adding user @zklaus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @jhamman @khallock @ocefpaf @snowman2 @xylar
+* @zklaus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ about:
 
 extra:
   recipe-maintainers:
+    - zklaus
     - ocefpaf
     - jhamman
     - khallock


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @zklaus as instructed in #30.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #30